### PR TITLE
fix: Correct import of Vue 'Ref' type

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -165,7 +165,8 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
-import { ref, nextTick, watch, Ref } from 'vue';
+import { ref, nextTick, watch } from 'vue';
+import type { Ref } from 'vue';
 // Đảm bảo bạn đã cài đặt lucide-vue-next: npm install lucide-vue-next
 // Lucide icons are auto-imported by nuxt-lucide-icons module as Icon<Name>
 


### PR DESCRIPTION
Changed the combined runtime and type import for 'Ref' in `layouts/default.vue` from:
  `import { ref, nextTick, watch, Ref } from 'vue';`
to separate imports:
  `import { ref, nextTick, watch } from 'vue';`
  `import type { Ref } from 'vue';`

This resolves the runtime error "The requested module vue.runtime.esm-bundler.js does not provide an export named 'Ref'" by correctly specifying that 'Ref' is a type-only import and not a runtime JavaScript export from the 'vue' module.