### PR TITLE
feat: Implement header dark mode and add more homepage sections

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,21 +1,21 @@
 <template>
-  <header class="bg-white border-b border-border text-slate-900 fixed top-0 left-0 right-0 z-50 h-16">
+  <header class="bg-background border-b border-border text-foreground fixed top-0 left-0 right-0 z-50 h-16">
     <div class="container mx-auto h-full flex items-center justify-between px-4">
       <!-- Logo -->
-      <NuxtLink to="/" class="text-2xl font-bold text-slate-800 hover:opacity-80 transition-opacity">
+      <NuxtLink to="/" class="text-2xl font-bold text-foreground hover:opacity-80 transition-opacity">
         MyAppLogo
       </NuxtLink>
 
       <!-- Desktop Navigation & Actions -->
       <nav class="hidden md:flex items-center space-x-4">
-        <NuxtLink to="/" class="text-slate-700 hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Home</NuxtLink>
-        <NuxtLink to="/books" class="text-slate-700 hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Books</NuxtLink>
-        <NuxtLink to="/about" class="text-slate-700 hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">About</NuxtLink>
+        <NuxtLink to="/" class="text-muted-foreground hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Home</NuxtLink>
+        <NuxtLink to="/books" class="text-muted-foreground hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Books</NuxtLink>
+        <NuxtLink to="/about" class="text-muted-foreground hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">About</NuxtLink>
 
         <template v-if="isLoggedIn">
-          <NuxtLink to="/profile" class="text-slate-700 hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Profile</NuxtLink>
-          <NuxtLink to="/settings" class="text-slate-700 hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Settings</NuxtLink>
-          <Button variant="ghost" size="sm" @click="handleLogout" class="text-slate-700 hover:text-primary hover:bg-slate-100">Logout</Button>
+          <NuxtLink to="/profile" class="text-muted-foreground hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Profile</NuxtLink>
+          <NuxtLink to="/settings" class="text-muted-foreground hover:text-primary transition-colors px-3 py-2 rounded-md text-sm font-medium">Settings</NuxtLink>
+          <Button variant="ghost" size="sm" @click="handleLogout" class="text-muted-foreground hover:text-primary hover:bg-accent px-3 py-2 text-sm font-medium">Logout</Button>
         </template>
         <template v-else>
           <NuxtLink to="/auth/login">
@@ -25,7 +25,7 @@
         </template>
 
         <!-- Theme Switcher Button (Desktop) -->
-        <Button variant="ghost" size="icon" @click="toggleTheme" aria-label="Toggle theme" class="text-slate-700 hover:text-primary hover:bg-slate-100">
+        <Button variant="ghost" size="icon" @click="toggleTheme" aria-label="Toggle theme" class="text-muted-foreground hover:text-primary hover:bg-accent">
           <IconSun v-if="currentTheme === 'light'" class="h-5 w-5" />
           <IconMoon v-else class="h-5 w-5" /> <!-- Only two states now -->
         </Button>
@@ -33,7 +33,7 @@
 
       <!-- Mobile Menu Button -->
       <div class="md:hidden">
-        <Button variant="ghost" size="icon" @click="mobileMenuOpen = !mobileMenuOpen" aria-label="Open menu" class="text-slate-700 hover:text-primary hover:bg-slate-100">
+        <Button variant="ghost" size="icon" @click="mobileMenuOpen = !mobileMenuOpen" aria-label="Open menu" class="text-muted-foreground hover:text-primary hover:bg-accent">
           <IconMenu class="h-6 w-6" />
         </Button>
       </div>
@@ -48,24 +48,24 @@
       leave-from-class="opacity-100 translate-y-0"
       leave-to-class="opacity-0 translate-y-1"
     >
-      <div v-if="mobileMenuOpen" class="md:hidden absolute top-16 left-0 right-0 bg-white shadow-lg z-40 border-b border-border">
+      <div v-if="mobileMenuOpen" class="md:hidden absolute top-16 left-0 right-0 bg-background border-t border-border shadow-lg z-40">
         <nav class="container mx-auto flex flex-col px-4 py-2 space-y-1">
-          <NuxtLink to="/" class="text-slate-700 hover:bg-slate-100 hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Home</NuxtLink>
-          <NuxtLink to="/books" class="text-slate-700 hover:bg-slate-100 hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Books</NuxtLink>
-          <NuxtLink to="/about" class="text-slate-700 hover:bg-slate-100 hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">About</NuxtLink>
+          <NuxtLink to="/" class="text-muted-foreground hover:bg-accent hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Home</NuxtLink>
+          <NuxtLink to="/books" class="text-muted-foreground hover:bg-accent hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Books</NuxtLink>
+          <NuxtLink to="/about" class="text-muted-foreground hover:bg-accent hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">About</NuxtLink>
 
           <template v-if="isLoggedIn">
-            <NuxtLink to="/profile" class="text-slate-700 hover:bg-slate-100 hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Profile</NuxtLink>
-            <NuxtLink to="/settings" class="text-slate-700 hover:bg-slate-100 hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Settings</NuxtLink>
-            <Button variant="ghost" class="w-full justify-start px-3 py-2 text-base font-medium text-slate-700 hover:bg-slate-100 hover:text-primary" @click="handleLogoutAndCloseMenu">Logout</Button>
+            <NuxtLink to="/profile" class="text-muted-foreground hover:bg-accent hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Profile</NuxtLink>
+            <NuxtLink to="/settings" class="text-muted-foreground hover:bg-accent hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Settings</NuxtLink>
+            <Button variant="ghost" class="w-full justify-start px-3 py-2 text-base font-medium text-muted-foreground hover:bg-accent hover:text-primary" @click="handleLogoutAndCloseMenu">Logout</Button>
           </template>
           <template v-else>
-            <NuxtLink to="/auth/login" class="text-slate-700 hover:bg-slate-100 hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Login</NuxtLink>
+            <NuxtLink to="/auth/login" class="text-muted-foreground hover:bg-accent hover:text-primary transition-colors block px-3 py-2 rounded-md text-base font-medium" @click="closeMobileMenu">Login</NuxtLink>
             <!-- Register button removed from mobile menu non-logged-in state -->
           </template>
 
           <div class="border-t border-border pt-2 mt-2">
-             <Button variant="ghost" class="w-full justify-start px-3 py-2 text-base font-medium flex items-center gap-2 text-slate-700 hover:bg-slate-100 hover:text-primary" @click="toggleThemeAndCloseMenu" aria-label="Toggle theme">
+             <Button variant="ghost" class="w-full justify-start px-3 py-2 text-base font-medium flex items-center gap-2 text-muted-foreground hover:bg-accent hover:text-primary" @click="toggleThemeAndCloseMenu" aria-label="Toggle theme">
                 <IconSun v-if="currentTheme === 'light'" class="h-5 w-5" />
                 <IconMoon v-else class="h-5 w-5" />
                 <span>Change to {{ currentTheme === 'light' ? 'Dark' : 'Light' }} Mode</span>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -135,6 +135,51 @@
         </div>
       </div>
     </section>
+
+    <!-- How It Works Section -->
+    <section id="how-it-works" class="py-16 md:py-24 bg-muted/50 dark:bg-muted/20">
+      <div class="container mx-auto px-4">
+        <h2 data-aos="fade-up" class="text-3xl md:text-4xl font-bold text-center mb-12">
+          Getting Started is <span class="text-primary">Easy</span>
+        </h2>
+        <div class="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+          <div data-aos="fade-up" data-aos-delay="0" class="flex flex-col items-center text-center p-6">
+            <div class="bg-primary text-primary-foreground rounded-full w-16 h-16 flex items-center justify-center text-2xl font-bold mb-4">1</div>
+            <h3 class="text-xl font-semibold mb-2">Sign Up</h3>
+            <p class="text-muted-foreground text-sm">Create your free account in minutes to unlock a world of books.</p>
+          </div>
+          <div data-aos="fade-up" data-aos-delay="150" class="flex flex-col items-center text-center p-6">
+            <div class="bg-primary text-primary-foreground rounded-full w-16 h-16 flex items-center justify-center text-2xl font-bold mb-4">2</div>
+            <h3 class="text-xl font-semibold mb-2">Explore & Discover</h3>
+            <p class="text-muted-foreground text-sm">Browse our vast library, find new authors, and get personalized recommendations.</p>
+          </div>
+          <div data-aos="fade-up" data-aos-delay="300" class="flex flex-col items-center text-center p-6">
+            <div class="bg-primary text-primary-foreground rounded-full w-16 h-16 flex items-center justify-center text-2xl font-bold mb-4">3</div>
+            <h3 class="text-xl font-semibold mb-2">Read Anywhere</h3>
+            <p class="text-muted-foreground text-sm">Enjoy your books on any device with our customizable and friendly reader.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Final Call to Action (CTA) Section -->
+    <section id="final-cta" class="py-20 md:py-32 bg-background text-center">
+      <div class="container mx-auto px-4">
+        <h2 data-aos="zoom-in" class="text-3xl sm:text-4xl md:text-5xl font-bold mb-6 tracking-tight">
+          Ready to Dive Into Your Next Adventure?
+        </h2>
+        <p data-aos="fade-up" data-aos-delay="200" class="text-lg sm:text-xl text-muted-foreground max-w-xl mx-auto mb-10">
+          Join MyAppLogo today and start exploring. Your next favorite story awaits!
+        </p>
+        <div data-aos="fade-up" data-aos-delay="400">
+          <NuxtLink to="/auth/register">
+            <Button size="lg" class="px-10 py-3 text-lg">
+              Sign Up For Free
+            </Button>
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
   </div>
 </template>
 


### PR DESCRIPTION
This commit introduces two main enhancements:
1.  **Header Dark Mode Compatibility:**
    - Updated `AppHeader.vue` to use theme-aware Shadcn UI/Tailwind classes (e.g., `bg-background`, `text-foreground`, `text-muted-foreground`).
    - This ensures the header, including its logo, navigation links, icon buttons, and the mobile menu, correctly adapts its appearance when switching between light and dark themes.

2.  **Additional Homepage Sections (`pages/index.vue`):**
    - **"How It Works" Section:** Added a section explaining the basic steps for you to get started (Sign Up, Explore, Read), styled with numbered circles and descriptions.
    - **"Final Call to Action (CTA)" Section:** Included a prominent CTA at the end of the landing page content to encourage your registration.
    - Both new sections are integrated with AOS (Animate On Scroll) for engaging scroll-triggered animations.

These changes improve the visual consistency of the header across themes and further enrich the homepage content for a more complete landing page experience.